### PR TITLE
Hotfix/issue#315 security bulk operations

### DIFF
--- a/Database/Seeders/json/permissions.json
+++ b/Database/Seeders/json/permissions.json
@@ -467,5 +467,11 @@
         "module": "vaahcms",
         "section": "taxonomy",
         "details": "This will allow user to manage anything in the taxonomy type modal."
+    },
+    {
+        "name": "Can Update Failed Jobs",
+        "module": "vaahcms",
+        "section": "failedjobs",
+        "details": "This will allow user to update failed jobs."
     }
 ]

--- a/Http/Controllers/Backend/Advanced/BatchesController.php
+++ b/Http/Controllers/Backend/Advanced/BatchesController.php
@@ -101,6 +101,18 @@ class BatchesController extends Controller
     //----------------------------------------------------------
     public function listAction(Request $request, $type): JsonResponse
     {
+        $permissions = [
+            'can-update-batch',
+            'can-delete-batch'
+        ];
+
+        $hasPermission = collect($permissions)->contains(function ($perm) {
+            return Auth::user()->hasPermission($perm);
+        });
+
+        if (!$hasPermission) {
+            return vh_get_permission_denied_json_response(implode(' or ', $permissions));
+        }
         try {
             $response = Batch::listAction($request, $type);
         } catch (\Exception $e) {

--- a/Http/Controllers/Backend/Advanced/BatchesController.php
+++ b/Http/Controllers/Backend/Advanced/BatchesController.php
@@ -126,10 +126,11 @@ class BatchesController extends Controller
     //----------------------------------------------------------
     public function deleteList(Request $request): JsonResponse
     {
-        $permission_slug = 'can-delete-batch';
+        $permission_slugs = ['can-delete-batch','can-update-batch'];
+        $permission_response = Auth::user()->hasPermissions($permission_slugs);
 
-        if(!Auth::user()->hasPermission($permission_slug)) {
-            return vh_get_permission_denied_json_response($permission_slug);
+        if(isset($permission_response['success']) && $permission_response['success'] == false) {
+            return response()->json($permission_response);
         }
         try {
             $response = Batch::deleteList($request);
@@ -150,10 +151,12 @@ class BatchesController extends Controller
     //----------------------------------------------------------
     public function deleteItem(Request $request, $id): JsonResponse
     {
-        $permission_slug = 'can-delete-batch';
 
-        if(!Auth::user()->hasPermission($permission_slug)) {
-            return vh_get_permission_denied_json_response($permission_slug);
+        $permission_slugs = ['can-delete-batch','can-update-batch'];
+        $permission_response = Auth::user()->hasPermissions($permission_slugs);
+
+        if(isset($permission_response['success']) && $permission_response['success'] == false) {
+            return response()->json($permission_response);
         }
         try {
             $request->merge(['inputs' => [$id]]);

--- a/Http/Controllers/Backend/Advanced/BatchesController.php
+++ b/Http/Controllers/Backend/Advanced/BatchesController.php
@@ -101,18 +101,12 @@ class BatchesController extends Controller
     //----------------------------------------------------------
     public function listAction(Request $request, $type): JsonResponse
     {
-        $permissions = [
-            'can-update-batch',
-            'can-delete-batch'
-        ];
+        $permission_slug = 'can-update-batch';
 
-        $hasPermission = collect($permissions)->contains(function ($perm) {
-            return Auth::user()->hasPermission($perm);
-        });
-
-        if (!$hasPermission) {
-            return vh_get_permission_denied_json_response(implode(' or ', $permissions));
+        if(!Auth::user()->hasPermission($permission_slug)) {
+            return vh_get_permission_denied_json_response($permission_slug);
         }
+
         try {
             $response = Batch::listAction($request, $type);
         } catch (\Exception $e) {

--- a/Http/Controllers/Backend/Advanced/BatchesController.php
+++ b/Http/Controllers/Backend/Advanced/BatchesController.php
@@ -132,6 +132,11 @@ class BatchesController extends Controller
     //----------------------------------------------------------
     public function deleteList(Request $request): JsonResponse
     {
+        $permission_slug = 'can-delete-batch';
+
+        if(!Auth::user()->hasPermission($permission_slug)) {
+            return vh_get_permission_denied_json_response($permission_slug);
+        }
         try {
             $response = Batch::deleteList($request);
         } catch (\Exception $e) {

--- a/Http/Controllers/Backend/Advanced/BatchesController.php
+++ b/Http/Controllers/Backend/Advanced/BatchesController.php
@@ -150,6 +150,11 @@ class BatchesController extends Controller
     //----------------------------------------------------------
     public function deleteItem(Request $request, $id): JsonResponse
     {
+        $permission_slug = 'can-delete-batch';
+
+        if(!Auth::user()->hasPermission($permission_slug)) {
+            return vh_get_permission_denied_json_response($permission_slug);
+        }
         try {
             $request->merge(['inputs' => [$id]]);
             $response = Batch::bulkDelete($request);
@@ -170,6 +175,11 @@ class BatchesController extends Controller
     //----------------------------------------------------------
     public function itemAction(Request $request, $id, $action): JsonResponse
     {
+        $permission_slug = 'can-update-batch';
+
+        if(!Auth::user()->hasPermission($permission_slug)) {
+            return vh_get_permission_denied_json_response($permission_slug);
+        }
         try {
             $response = Batch::itemAction($request, $id, $action);
         } catch (\Exception $e) {

--- a/Http/Controllers/Backend/Advanced/FailedJobsController.php
+++ b/Http/Controllers/Backend/Advanced/FailedJobsController.php
@@ -121,10 +121,11 @@ class FailedJobsController extends Controller
     public function listAction(Request $request, $type): JsonResponse
     {
 
-        $permission_slug = 'can-update-failed-jobs';
+        $permission_slugs = ['can-delete-failed-jobs','can-update-failed-jobs'];
+        $permission_response = Auth::user()->hasPermissions($permission_slugs);
 
-        if(!Auth::user()->hasPermission($permission_slug)) {
-            return vh_get_permission_denied_json_response($permission_slug);
+        if(isset($permission_response['success']) && $permission_response['success'] == false) {
+            return response()->json($permission_response);
         }
         try {
             $response = FailedJob::listAction($request, $type);
@@ -145,10 +146,11 @@ class FailedJobsController extends Controller
     //----------------------------------------------------------
     public function deleteList(Request $request): JsonResponse
     {
-        $permission_slug = 'can-delete-failed-jobs';
+        $permission_slugs = ['can-delete-failed-jobs','can-update-failed-jobs'];
+        $permission_response = Auth::user()->hasPermissions($permission_slugs);
 
-        if(!Auth::user()->hasPermission($permission_slug)) {
-            return vh_get_permission_denied_json_response($permission_slug);
+        if(isset($permission_response['success']) && $permission_response['success'] == false) {
+            return response()->json($permission_response);
         }
 
         try {
@@ -170,6 +172,12 @@ class FailedJobsController extends Controller
     //----------------------------------------------------------
     public function deleteItem(Request $request, $id): JsonResponse
     {
+        $permission_slugs = ['can-delete-failed-jobs','can-update-failed-jobs'];
+        $permission_response = Auth::user()->hasPermissions($permission_slugs);
+
+        if(isset($permission_response['success']) && $permission_response['success'] == false) {
+            return response()->json($permission_response);
+        }
         try {
             $response = FailedJob::deleteItem($request, $id);
         } catch (\Exception $e) {

--- a/Http/Controllers/Backend/Advanced/FailedJobsController.php
+++ b/Http/Controllers/Backend/Advanced/FailedJobsController.php
@@ -121,17 +121,10 @@ class FailedJobsController extends Controller
     public function listAction(Request $request, $type): JsonResponse
     {
 
-        $permissions = [
-            'can-update-failed-jobs',
-            'can-delete-failed-jobs'
-        ];
+        $permission_slug = 'can-update-failed-jobs';
 
-        $hasPermission = collect($permissions)->contains(function ($perm) {
-            return Auth::user()->hasPermission($perm);
-        });
-
-        if (!$hasPermission) {
-            return vh_get_permission_denied_json_response(implode(' or ', $permissions));
+        if(!Auth::user()->hasPermission($permission_slug)) {
+            return vh_get_permission_denied_json_response($permission_slug);
         }
         try {
             $response = FailedJob::listAction($request, $type);

--- a/Http/Controllers/Backend/Advanced/FailedJobsController.php
+++ b/Http/Controllers/Backend/Advanced/FailedJobsController.php
@@ -121,10 +121,18 @@ class FailedJobsController extends Controller
     public function listAction(Request $request, $type): JsonResponse
     {
 
-        $permission_slug_update = 'can-update-failed-jobs';
-        $permission_slug_delete = 'can-delete-failed-jobs';
+        $permissions = [
+            'can-update-failed-jobs',
+            'can-delete-failed-jobs'
+        ];
 
+        $hasPermission = collect($permissions)->contains(function ($perm) {
+            return Auth::user()->hasPermission($perm);
+        });
 
+        if (!$hasPermission) {
+            return vh_get_permission_denied_json_response(implode(' or ', $permissions));
+        }
         try {
             $response = FailedJob::listAction($request, $type);
         } catch (\Exception $e) {

--- a/Http/Controllers/Backend/Advanced/FailedJobsController.php
+++ b/Http/Controllers/Backend/Advanced/FailedJobsController.php
@@ -120,6 +120,11 @@ class FailedJobsController extends Controller
     //----------------------------------------------------------
     public function listAction(Request $request, $type): JsonResponse
     {
+
+        $permission_slug_update = 'can-update-failed-jobs';
+        $permission_slug_delete = 'can-delete-failed-jobs';
+
+
         try {
             $response = FailedJob::listAction($request, $type);
         } catch (\Exception $e) {
@@ -139,6 +144,12 @@ class FailedJobsController extends Controller
     //----------------------------------------------------------
     public function deleteList(Request $request): JsonResponse
     {
+        $permission_slug = 'can-delete-failed-jobs';
+
+        if(!Auth::user()->hasPermission($permission_slug)) {
+            return vh_get_permission_denied_json_response($permission_slug);
+        }
+
         try {
             $response = FailedJob::deleteList($request);
         } catch (\Exception $e) {

--- a/Http/Controllers/Backend/Advanced/FailedJobsController.php
+++ b/Http/Controllers/Backend/Advanced/FailedJobsController.php
@@ -96,6 +96,11 @@ class FailedJobsController extends Controller
     //----------------------------------------------------------
     public function updateList(Request $request): JsonResponse
     {
+        $permission_slug = 'can-update-failed-jobs';
+
+        if(!Auth::user()->hasPermission($permission_slug)) {
+            return vh_get_permission_denied_json_response($permission_slug);
+        }
         try {
             $response = FailedJob::updateList($request);
         } catch (\Exception $e) {

--- a/Http/Controllers/Backend/Advanced/JobsController.php
+++ b/Http/Controllers/Backend/Advanced/JobsController.php
@@ -102,6 +102,13 @@ class JobsController extends Controller
 
     public function listAction(Request $request, $type): JsonResponse
     {
+
+        $permission_slugs = ['can-delete-jobs','can-update-jobs'];
+        $permission_response = Auth::user()->hasPermissions($permission_slugs);
+
+        if(isset($permission_response['success']) && $permission_response['success'] == false) {
+            return response()->json($permission_response);
+        }
         try {
             $response = Job::listAction($request, $type);
         } catch (\Exception $e) {
@@ -121,6 +128,13 @@ class JobsController extends Controller
     //----------------------------------------------------------
     public function deleteList(Request $request): JsonResponse
     {
+
+        $permission_slugs = ['can-delete-jobs','can-update-jobs'];
+        $permission_response = Auth::user()->hasPermissions($permission_slugs);
+
+        if(isset($permission_response['success']) && $permission_response['success'] == false) {
+            return response()->json($permission_response);
+        }
         try {
             $response = Job::deleteList($request);
         } catch (\Exception $e) {
@@ -140,6 +154,12 @@ class JobsController extends Controller
     //----------------------------------------------------------
     public function deleteItem(Request $request, $id): JsonResponse
     {
+        $permission_slugs = ['can-delete-jobs','can-update-jobs'];
+        $permission_response = Auth::user()->hasPermissions($permission_slugs);
+
+        if(isset($permission_response['success']) && $permission_response['success'] == false) {
+            return response()->json($permission_response);
+        }
         try {
             $response = Job::deleteItem($request,$id);
         } catch (\Exception $e) {
@@ -159,6 +179,11 @@ class JobsController extends Controller
     //----------------------------------------------------------
     public function itemAction(Request $request, $id, $action): JsonResponse
     {
+        $permission_slug = 'can-update-jobs';
+
+        if(!Auth::user()->hasPermission($permission_slug)) {
+            return vh_get_permission_denied_json_response($permission_slug);
+        }
         try {
             $response = Job::itemAction($request, $id, $action);
         } catch (\Exception $e) {

--- a/Http/Controllers/Backend/UsersController.php
+++ b/Http/Controllers/Backend/UsersController.php
@@ -181,6 +181,11 @@ class UsersController extends Controller
     //----------------------------------------------------------
     public function deleteList(Request $request): JsonResponse
     {
+        $permission_slug = 'can-delete-users';
+
+        if(!Auth::user()->hasPermission($permission_slug)) {
+            return vh_get_permission_denied_json_response($permission_slug);
+        }
         try {
             $response = User::deleteList($request);
         } catch (\Exception $e) {


### PR DESCRIPTION
## Fix: Add missing permission checks to bulk operations across controllers

### Description
This PR fixes critical authorization gaps where bulk operations were skipping permission checks, allowing unauthorized users to perform destructive actions.

---

### Changes Implemented
- Added permission checks to bulk endpoints to match single-item operations
- Ensured consistent use of `hasPermission()` / `hasPermissions()` across controllers

---

### Fixed Issues

1. **UsersController::deleteList()**
   - Added `can-delete-users` permission check

2. **FailedJobsController**
   - `updateList()` → Added `can-update-failed-jobs`
   - `listAction()` → Added action-based permission checks

3. **BatchesController**
   - `deleteList()` → Added delete permission check  
   - `listAction()` → Added action-based permission validation  

---

### Root Cause
Bulk operations did not enforce authorization checks, while single-item operations already had proper permission validation. This PR aligns both behaviors.

---

### Impact
- Prevents unauthorized bulk delete/update/actions
- Ensures consistent and secure permission handling across the application
