### PR TITLE
2.x feature/send otp on both emails

### DIFF
--- a/Config/vaahcms.php
+++ b/Config/vaahcms.php
@@ -8,7 +8,7 @@
 $settings =  [
     'app_name' => 'VaahCMS',
     'app_slug' => 'vaahcms',
-    'version' => '2.3.5',
+    'version' => '2.3.6',
     'php_version_required' => '8.1',
     'get_config_version' => false,
     'website' => 'https://vaah.dev/cms',

--- a/Models/Notification.php
+++ b/Models/Notification.php
@@ -528,7 +528,16 @@ class Notification extends VaahModel {
     //-------------------------------------------------
     public static function sendViaMail(Notification $notification, User $user, $params=[])
     {
-        $user->notify(new Notice($notification, $params));
+        // Email
+        if (!empty($user->email)) {
+            $user->notify(new Notice($notification, $params));
+        }
+
+        // Alternate Email
+        if (!empty($user->alternate_email) && $user->alternate_email !== $user->email) {
+            \Notification::route('mail', $user->alternate_email)
+                ->notify(new Notice($notification, $params));
+        }
     }
     //-------------------------------------------------
     public static function sendViaBackend(Notification $notification, User $user, $params=[])

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "webreinvent/vaahcms",
-    "version": "2.3.5",
+    "version": "2.3.6",
     "description": "VaahCMS is a laravel based open-source web application development platform shipped with headless content management system.",
     "keywords": ["vaahcms", "headless", "hmvc", "laravel", "cms", "vue", "pinia"],
     "homepage": "https://webreinvent.com",


### PR DESCRIPTION
## Send Notification to Alternative Email

### Description  
This update ensures that notifications (such as OTPs, alerts, or system emails) are also sent to the user's alternative email address, if it is available.

### Key Points  
- Sends email to the primary email address by default  
- Also sends the same email to the alternative email (if provided)  
- Skips sending to alternative email if the field is null or empty  
- Helps improve delivery reliability and user accessibility  

### Behavior  
- If `alternate_email` exists → send to both primary and alternative emails  
- If `alternate_email` is null → send only to primary email  

### Benefit  
Ensures users receive important communications even if one email is inaccessible or missed.